### PR TITLE
Added histogram to measure http response time

### DIFF
--- a/cmd/snmp_test.go
+++ b/cmd/snmp_test.go
@@ -11,13 +11,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/require"
 	snmp_cmd "github.com/cisco-cx/of/cmd"
 	of_v2 "github.com/cisco-cx/of/pkg/v2"
 	http "github.com/cisco-cx/of/wrap/http/v2"
 	logger "github.com/cisco-cx/of/wrap/logrus/v2"
 	snmp "github.com/cisco-cx/of/wrap/snmp/v2"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
 )
 
 // Test SNMP mibs pre process
@@ -112,7 +112,7 @@ func startFakeAM(t *testing.T, amAddress string) *http.Server {
 
 	hc := &of_v2.HTTPConfig{ListenAddress: amAddress, ReadTimeout: 1 * time.Second, WriteTimeout: 1 * time.Second}
 
-	srv := http.NewServer(hc)
+	srv := http.NewServer(hc, t.Name())
 	srv.HandleFunc("/-/healthy", func(w of_v2.ResponseWriter, r of_v2.Request) {
 		w.WriteHeader(http.StatusBadGateway)
 	})

--- a/pkg/v2/http.go
+++ b/pkg/v2/http.go
@@ -31,6 +31,7 @@ type Server struct {
 	Srv *http.Server
 	Mux *http.ServeMux
 	G   Graceful
+	M   Measurer
 }
 
 // Represents HTTP handler
@@ -48,6 +49,11 @@ type Serve interface {
 
 // Represents HTTP client
 type Client http.Client
+
+// Represents HTTP Response code/time measurements
+type Measurer interface {
+	Measure(ResponseWriter, Request, func(ResponseWriter, Request))
+}
 
 // Represents HTTP ResponseWriter
 type ResponseWriter interface {

--- a/pkg/v2/http.go
+++ b/pkg/v2/http.go
@@ -19,7 +19,6 @@ import (
 	"time"
 )
 
-type ResponseWriter http.ResponseWriter
 type Request *http.Request
 
 type HTTPConfig struct {
@@ -49,3 +48,11 @@ type Serve interface {
 
 // Represents HTTP client
 type Client http.Client
+
+// Represents HTTP ResponseWriter
+type ResponseWriter interface {
+	Header() http.Header
+	Write([]byte) (int, error)
+	WriteHeader(int)
+	StatusCode() int
+}

--- a/wrap/aci/v1/handler.go
+++ b/wrap/aci/v1/handler.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"time"
 
-	consul "github.com/hashicorp/consul/api"
-	"github.com/mitchellh/mapstructure"
 	of "github.com/cisco-cx/of/pkg/v1"
 	aci_config "github.com/cisco-cx/of/pkg/v1/aci"
 	of_v2 "github.com/cisco-cx/of/pkg/v2"
@@ -32,6 +30,8 @@ import (
 	logger "github.com/cisco-cx/of/wrap/logrus/v1"
 	prometheus "github.com/cisco-cx/of/wrap/prometheus/client_golang/v2"
 	yaml "github.com/cisco-cx/of/wrap/yaml/v1"
+	consul "github.com/hashicorp/consul/api"
+	"github.com/mitchellh/mapstructure"
 )
 
 // Alertmanager alert specific constants.
@@ -104,13 +104,12 @@ func (h *Handler) Run() {
 		ReadTimeout:   h.Config.ACITimeout,
 		WriteTimeout:  h.Config.ACITimeout,
 	}
-	h.server = http.NewServer(&httpConfig)
+	h.server = http.NewServer(&httpConfig, h.Config.Application)
 
 	h.server.HandleFunc("/", func(w of_v2.ResponseWriter, r of_v2.Request) {
 		fmt.Fprint(w, h.Config.Version)
 	})
 
-	h.server.Handle("/metrics", prometheus.NewHandler())
 	err := h.server.ListenAndServe()
 	if err != nil {
 		h.Log.WithError(err).Fatalf("Failed to listen at %s", h.Config.ListenAddress)

--- a/wrap/alertmanager/v2/alertmanager_test.go
+++ b/wrap/alertmanager/v2/alertmanager_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	of "github.com/cisco-cx/of/pkg/v2"
 	am "github.com/cisco-cx/of/wrap/alertmanager/v2"
 	http "github.com/cisco-cx/of/wrap/http/v2"
 	logger "github.com/cisco-cx/of/wrap/logrus/v2"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDryRun(t *testing.T) {
@@ -20,7 +20,7 @@ func TestDryRun(t *testing.T) {
 
 	hc := &of.HTTPConfig{ListenAddress: addr, ReadTimeout: timeout, WriteTimeout: timeout}
 
-	srv := http.NewServer(hc)
+	srv := http.NewServer(hc, t.Name())
 	srv.HandleFunc("/api/v1/alerts", func(w of.ResponseWriter, r of.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	})

--- a/wrap/health/v2/health_test.go
+++ b/wrap/health/v2/health_test.go
@@ -127,7 +127,7 @@ func TestHealthChecker_State(t *testing.T) {
 	thc.msg = make(chan string, 1)
 
 	hc := &of.HTTPConfig{ListenAddress: "localhost:63333", ReadTimeout: 5 * time.Second, WriteTimeout: 5 * time.Second}
-	srv := http.NewServer(hc)
+	srv := http.NewServer(hc, t.Name())
 	srv.HandleFunc("/foo", thc.UrlHandler)
 	srv.HandleFunc("/bar", thc.UrlHandler)
 

--- a/wrap/http/v2/client_test.go
+++ b/wrap/http/v2/client_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-	"gotest.tools/assert"
 	of "github.com/cisco-cx/of/pkg/v2"
 	http "github.com/cisco-cx/of/wrap/http/v2"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
 )
 
 // Test http.Get
@@ -34,7 +34,7 @@ func startServer(t *testing.T, server_addr string) *http.Server {
 
 	c := &of.HTTPConfig{ListenAddress: server_addr}
 
-	srv := http.NewServer(c)
+	srv := http.NewServer(c, t.Name())
 	srv.HandleFunc("/", func(w of.ResponseWriter, r of.Request) {
 		fmt.Fprint(w, response_text)
 	})

--- a/wrap/http/v2/handler.go
+++ b/wrap/http/v2/handler.go
@@ -13,5 +13,6 @@ type handlerOveride struct {
 
 // Pass on http.ResponseWriter and http.Request to of.Handler
 func (h *handlerOveride) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
-	h.serverHTTP(rw, r)
+	wrappedRW := NewResponseWriter(rw)
+	h.serverHTTP(wrappedRW, r)
 }

--- a/wrap/http/v2/handler.go
+++ b/wrap/http/v2/handler.go
@@ -8,11 +8,12 @@ import (
 
 // Interface to convert of.* to http.*
 type handlerOveride struct {
+	m          of.Measurer
 	serverHTTP func(of.ResponseWriter, of.Request)
 }
 
 // Pass on http.ResponseWriter and http.Request to of.Handler
 func (h *handlerOveride) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	wrappedRW := NewResponseWriter(rw)
-	h.serverHTTP(wrappedRW, r)
+	h.m.Measure(wrappedRW, r, h.serverHTTP)
 }

--- a/wrap/http/v2/measure.go
+++ b/wrap/http/v2/measure.go
@@ -1,0 +1,43 @@
+// Copyright 2019 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"path/filepath"
+	"strconv"
+	"time"
+
+	of "github.com/cisco-cx/of/pkg/v2"
+	promclient "github.com/cisco-cx/of/wrap/prometheus/client_golang/v2"
+)
+
+// Implements of.Measurer
+type Measurer struct {
+	HistVec *promclient.HistogramVec
+}
+
+// Method to measure http response as a prometheus metric.
+func (m *Measurer) Measure(rw of.ResponseWriter, r of.Request, fn func(rw of.ResponseWriter, r of.Request)) {
+	t1 := time.Now()
+	fn(rw, r)
+	t2 := time.Now().Sub(t1).Seconds()
+
+	values := []string{
+		r.Method,
+		filepath.Join(r.Host, r.URL.Path),
+		strconv.Itoa(rw.StatusCode()),
+	}
+	m.HistVec.Observed(values, t2)
+}

--- a/wrap/http/v2/measure_test.go
+++ b/wrap/http/v2/measure_test.go
@@ -1,0 +1,62 @@
+package v2_test
+
+import (
+	"io/ioutil"
+	go_http "net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	of "github.com/cisco-cx/of/pkg/v2"
+	http "github.com/cisco-cx/of/wrap/http/v2"
+	promclient "github.com/cisco-cx/of/wrap/prometheus/client_golang/v2"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/stretchr/testify/require"
+)
+
+// Enforce interface implementation.
+func TestMeasurerInterface(t *testing.T) {
+	var _ of.Measurer = &http.Measurer{}
+}
+
+// Test of.Measurer's Measure method
+func TestMeasure(t *testing.T) {
+
+	histVec := promclient.HistogramVec{Namespace: t.Name(), Name: "Test", Help: "Testing measure."}
+	err := histVec.Create([]string{"method", "uri", "status_code"})
+	require.NoError(t, err)
+
+	mr := http.Measurer{&histVec}
+
+	fn := func(rw of.ResponseWriter, r of.Request) {
+		time.Sleep(500 * time.Millisecond)
+		rw.WriteHeader(403)
+	}
+
+	w := httptest.NewRecorder()
+	rw := http.NewResponseWriter(w)
+	var r of.Request = &go_http.Request{
+		Method: "GET",
+		URL: &url.URL{
+			Host: "localhost",
+			Path: "/foobar",
+		},
+	}
+
+	mr.Measure(rw, r, fn)
+	metrics := promMetrics(t)
+	require.Contains(t, metrics, `TestMeasure_Test_bucket{method="GET",status_code="403",uri="/foobar",le="1"} 1`)
+}
+
+// Fetches current metrics.
+func promMetrics(t *testing.T) string {
+	ts := httptest.NewServer(promhttp.Handler())
+	defer ts.Close()
+	res, err := go_http.Get(ts.URL)
+	require.NoError(t, err)
+	defer res.Body.Close()
+	metrics, err := ioutil.ReadAll(res.Body)
+	require.NoError(t, err)
+	return string(metrics)
+}

--- a/wrap/http/v2/response_writer.go
+++ b/wrap/http/v2/response_writer.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"net/http"
+)
+
+// Wrapping net/http ResponseWriter
+type ResponseWriter struct {
+	hrw        http.ResponseWriter
+	statusCode int
+}
+
+// Initiate of.ResponseWriter
+func NewResponseWriter(hrw http.ResponseWriter) *ResponseWriter {
+	return &ResponseWriter{hrw, 200}
+}
+
+// Wrapping net/http ResponseWriter method
+func (rw *ResponseWriter) Header() http.Header {
+	return rw.hrw.Header()
+}
+
+// Wrapping net/http ResponseWriter method
+func (rw *ResponseWriter) Write(b []byte) (int, error) {
+	return rw.hrw.Write(b)
+}
+
+// Wrapping net/http ResponseWriter method and storing status code
+func (rw *ResponseWriter) WriteHeader(i int) {
+	rw.statusCode = i
+	rw.hrw.WriteHeader(i)
+}
+
+// Return statusCode saved by `WriteHeader` method
+func (rw *ResponseWriter) StatusCode() int {
+	return rw.statusCode
+}

--- a/wrap/http/v2/response_writer_test.go
+++ b/wrap/http/v2/response_writer_test.go
@@ -1,0 +1,13 @@
+package v2_test
+
+import (
+	"testing"
+
+	of "github.com/cisco-cx/of/pkg/v2"
+	http "github.com/cisco-cx/of/wrap/http/v2"
+)
+
+// Enforce interface implementation.
+func TestResponseWriterInterface(t *testing.T) {
+	var _ of.ResponseWriter = &http.ResponseWriter{}
+}

--- a/wrap/http/v2/server.go
+++ b/wrap/http/v2/server.go
@@ -91,7 +91,8 @@ func (s *Server) Handle(pattern string, h of.Handler) {
 // HandleFunc registers the handler function for the given pattern.
 func (s *Server) HandleFunc(pattern string, h func(of.ResponseWriter, of.Request)) {
 	newHandler := func(rw http.ResponseWriter, r *http.Request) {
-		h(rw, r)
+		wrappedRW := NewResponseWriter(rw)
+		h(wrappedRW, r)
 	}
 	s.Mux.HandleFunc(pattern, newHandler)
 }

--- a/wrap/http/v2/server_test.go
+++ b/wrap/http/v2/server_test.go
@@ -5,9 +5,9 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	of "github.com/cisco-cx/of/pkg/v2"
 	http "github.com/cisco-cx/of/wrap/http/v2"
+	"github.com/stretchr/testify/require"
 )
 
 // Implementation of of.Handler to test http.Handle
@@ -30,7 +30,7 @@ func TestServer(t *testing.T) {
 
 	c := &of.HTTPConfig{ListenAddress: addr}
 
-	srv := http.NewServer(c)
+	srv := http.NewServer(c, t.Name())
 
 	err := srv.ListenAndServe()
 	require.NoError(t, err)
@@ -45,7 +45,7 @@ func TestHandleFunc(t *testing.T) {
 	addr := "localhost:64932"
 	c := &of.HTTPConfig{ListenAddress: addr}
 
-	srv := http.NewServer(c)
+	srv := http.NewServer(c, t.Name())
 	srv.HandleFunc("/", func(w of.ResponseWriter, r of.Request) {
 		fmt.Fprint(w, response_text)
 	})
@@ -62,7 +62,7 @@ func TestHandle(t *testing.T) {
 	addr := "localhost:64933"
 	c := &of.HTTPConfig{ListenAddress: addr}
 
-	srv := http.NewServer(c)
+	srv := http.NewServer(c, t.Name())
 	srv.Handle("/", &testHandler{})
 
 	err := srv.ListenAndServe()

--- a/wrap/snmp/v2/handler.go
+++ b/wrap/snmp/v2/handler.go
@@ -8,7 +8,6 @@ import (
 	health "github.com/cisco-cx/of/wrap/health/v2"
 	http "github.com/cisco-cx/of/wrap/http/v2"
 	logger "github.com/cisco-cx/of/wrap/logrus/v2"
-	prometheus "github.com/cisco-cx/of/wrap/prometheus/client_golang/v2"
 )
 
 type Handler struct {
@@ -42,7 +41,7 @@ func (h *Handler) Run() {
 	h.Log.Debugf("Init health check.")
 
 	// Configure HTTP server to handle various requests.
-	h.server = http.NewServer(&httpConfig)
+	h.server = http.NewServer(&httpConfig, h.Config.Application)
 
 	h.server.HandleFunc("/", func(w of.ResponseWriter, r of.Request) {
 		h.Log.Tracef("Version endpoint accessed.")
@@ -62,10 +61,6 @@ func (h *Handler) Run() {
 		w.WriteHeader(http.StatusOK)
 	})
 	h.Log.Debugf("Added health handler.")
-
-	// Handling prometheus calls.
-	h.server.Handle("/metrics", prometheus.NewHandler())
-	h.Log.Debugf("Added metrics handler.")
 
 	// Handling status calls.
 	h.server.HandleFunc("/api/v2/status", func(w of.ResponseWriter, r of.Request) {

--- a/wrap/snmp/v2/handler_test.go
+++ b/wrap/snmp/v2/handler_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	of "github.com/cisco-cx/of/pkg/v2"
 	http "github.com/cisco-cx/of/wrap/http/v2"
 	snmp "github.com/cisco-cx/of/wrap/snmp/v2"
+	"github.com/stretchr/testify/require"
 )
 
 // Test Handler
@@ -30,7 +30,7 @@ func TestHandlerRun(t *testing.T) {
 	// Start fake AM Server.
 	hc := &of.HTTPConfig{ListenAddress: addr, ReadTimeout: cfg.AMTimeout, WriteTimeout: cfg.AMTimeout}
 
-	srv := http.NewServer(hc)
+	srv := http.NewServer(hc, t.Name())
 	srv.HandleFunc("/-/healthy", func(w of.ResponseWriter, r of.Request) {
 		w.WriteHeader(http.StatusBadGateway)
 	})

--- a/wrap/snmp/v2/service_test.go
+++ b/wrap/snmp/v2/service_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	of "github.com/cisco-cx/of/pkg/v2"
 	of_snmp "github.com/cisco-cx/of/pkg/v2/snmp"
 	herodot "github.com/cisco-cx/of/wrap/herodot/v2"
@@ -15,6 +14,7 @@ import (
 	snmp "github.com/cisco-cx/of/wrap/snmp/v2"
 	uuid "github.com/cisco-cx/of/wrap/uuid/v2"
 	yaml "github.com/cisco-cx/of/wrap/yaml/v2"
+	"github.com/stretchr/testify/require"
 )
 
 // Represents of.Notifier interface
@@ -85,7 +85,7 @@ func TestSNMPService(t *testing.T) {
 
 	hc := &of.HTTPConfig{ListenAddress: addr}
 
-	srv := http.NewServer(hc)
+	srv := http.NewServer(hc, t.Name())
 	srv.HandleFunc("/", s.AlertHandler)
 	err := srv.ListenAndServe()
 	require.NoError(t, err)


### PR DESCRIPTION
Had to wrap `net/http` `ResponseWriter` to expose `StatusCode`. Now all `http` request served will record the time taken by URL+path, response code and HTTP method.