### PR TITLE
Add support multiple aci hosts

### DIFF
--- a/cmd/aci.go
+++ b/cmd/aci.go
@@ -23,7 +23,6 @@ import (
 	aci "github.com/cisco-cx/of/wrap/aci/v1"
 	acigo "github.com/cisco-cx/of/wrap/acigo/v1"
 	alertmanager "github.com/cisco-cx/of/wrap/alertmanager/v1"
-	net "github.com/cisco-cx/of/wrap/net/v1"
 	profile "github.com/cisco-cx/of/wrap/profile/v1"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -63,8 +62,8 @@ func runACIHandler(cmd *cobra.Command, args []string) {
 	cmd.Flags().Int("aci-cycle-interval", 60, "Number of seconds to sleep between APIC -> AM notification cycles (default: 60)")
 	cmd.Flags().String("aci-am-url", "", "[Required] AlertManager's URL")
 	cmd.Flags().SetAnnotation("aci-am-url", "required", []string{"true"})
-	cmd.Flags().String("aci-host", "", "[Required] ACI host (Value is ignored when --aci-enable-consul is set")
-	cmd.Flags().SetAnnotation("aci-host", "required", []string{"true"})
+	cmd.Flags().String("aci-hosts", "localhost", "[Required] ACI hosts separated by ',' (Value is ignored when --aci-enable-consul is set")
+	cmd.Flags().SetAnnotation("aci-hosts", "required", []string{"true"})
 	cmd.Flags().String("aci-user", "", "[Required] ACI username")
 	cmd.Flags().SetAnnotation("aci-user", "required", []string{"true"})
 	cmd.Flags().String("aci-password", "", "[Required] ACI password")
@@ -78,20 +77,33 @@ func runACIHandler(cmd *cobra.Command, args []string) {
 	cmd.Flags().Int("aci-sleep-time", 100, "Time in ms, to sleep between HTTP POST to AM. (default: 100)")
 	cmd.Flags().Int("aci-send-time", 60000, "Time in ms, to complete HTTP POST to AM. (default: 60000)")
 	cmd.Flags().Bool("aci-enable-consul", false, "Whether to use consul for host discovery (default: false)")
+	cmd.Flags().String("consul-aci-group-host", "", "Consul group host used on filtering the host list (empty by default: matches everything)")
 	cmd.Flags().Bool("aci-debug", false, "Enable debug level logs for acigo. (default: false)")
 
 	checkRequiredFlags(cmd, args, []string{})
 
 	config := ACIConfig(cmd)
 
-	client, err := acigo.NewACIClient(of.ACIClientConfig{Hosts: []string{config.SourceHostname},
-		User: config.User, Pass: config.Pass, Debug: config.Debug}, log)
+	client, err := acigo.NewACIClient(of.ACIClientConfig{User: config.User, Pass: config.Pass, Debug: config.Debug}, log)
 	if err != nil {
 		log.WithError(err).Fatalf("Failed to get ACI client.")
 	}
 	handler := &aci.Handler{Config: config, Log: log, Aci: client}
 	handler.Ams = &alertmanager.AlertService{AmURL: config.AmURL, Version: config.Version}
 	handler.Run()
+}
+
+func parseHosts(hosts string) []string {
+	hostList := strings.Split(hosts, ",")
+	if len(hostList) < 1 {
+		log.Fatalf("Missing ACI hosts: %s", hosts)
+	}
+	for _, h := range hostList {
+		if strings.TrimSpace(h) == "" {
+			log.Fatalf("Blank ACI hostname '%s' in %s", h, hosts)
+		}
+	}
+	return hostList
 }
 
 // Returns  &ACI{} based on CLI flags and ENV.
@@ -101,7 +113,7 @@ func ACIConfig(cmd *cobra.Command) *of.ACIConfig {
 	cfg.ListenAddress = viper.GetString("aci-listen-address")
 	cfg.CycleInterval = viper.GetInt("aci-cycle-interval")
 	cfg.AmURL = viper.GetString("aci-am-url")
-	cfg.ACIHost = viper.GetString("aci-host")
+	cfg.ACIHosts = parseHosts(viper.GetString("aci-hosts"))
 
 	cfg.AlertsCFGFile = viper.GetString("aci-alerts-config")
 	cfg.SecretsCFGFile = viper.GetString("aci-secrets-config")
@@ -109,7 +121,6 @@ func ACIConfig(cmd *cobra.Command) *of.ACIConfig {
 	cfg.User = viper.GetString("aci-user")
 	cfg.Pass = viper.GetString("aci-password")
 	cfg.Version = infoSvc.String()
-	cfg.SourceHostname, cfg.SourceAddress = VerifiedHost(cfg.ACIHost)
 
 	cfg.ACITimeout = viper.GetDuration("aci-timeout")
 
@@ -119,6 +130,7 @@ func ACIConfig(cmd *cobra.Command) *of.ACIConfig {
 	cfg.SendTime = viper.GetInt("aci-send-time")
 
 	cfg.ConsulEnabled = viper.GetBool("aci-enable-consul")
+	cfg.ConsulACIGroupHost = viper.GetString("consul-aci-group-host")
 	cfg.Debug = viper.GetBool("aci-debug")
 
 	if strings.HasPrefix(cfg.AmURL, "http") == false {
@@ -144,49 +156,6 @@ func ACIConfig(cmd *cobra.Command) *of.ACIConfig {
 	log.Infof("This machine's timezone and offset are: %s, %d\n", zone, offset)
 
 	return cfg
-}
-
-// Do a forward and reverse lookup to verify the ACI Host.
-// If DNS entry is found, Hostname and IP from DNS Query is returned
-// else aciHost is returned
-func VerifiedHost(aciHost string) (string, string) {
-
-	hostname := aciHost
-	ipAddr := aciHost
-
-	// DNS reverse lookup
-	ip, err := net.NewIP(aciHost)
-	if err != nil {
-		log.WithError(err).Errorf("")
-	}
-
-	hostnames, err := ip.Hostnames()
-	if err != nil {
-		log.WithError(err).Errorf("Failed to find hostname.")
-	}
-	if len(hostnames) == 0 {
-		log.Errorf("No reverse lookup available for %s", ip.String())
-	} else {
-		hostname = string(hostnames[0])
-	}
-
-	// DNS forward lookup
-	host, err := net.NewHostname(hostname)
-	if err != nil {
-		log.WithError(err).Fatalf("")
-	}
-
-	var ips []of.IP
-	ips, err = host.IPv6()
-	if err != nil || len(ips) == 0 {
-		ips, err = host.IPv4()
-	}
-
-	if err == nil && len(ips) != 0 {
-		ipAddr = string(ips[len(ips)-1])
-	}
-
-	return hostname, ipAddr
 }
 
 // init creates and adds the `aci` command with its subcommands.

--- a/pkg/v1/aci.go
+++ b/pkg/v1/aci.go
@@ -46,26 +46,25 @@ import (
 
 // Represents ACI settings.
 type ACIConfig struct {
-	Application    string
-	ListenAddress  string
-	CycleInterval  int
-	ACITimeout     time.Duration
-	AmURL          string
-	ACIHost        string
-	AlertsCFGFile  string
-	SecretsCFGFile string
-	Version        string
-	User           string
-	Pass           string
-	ac             aci_config.Alerts
-	sc             aci_config.Secrets
-	SourceHostname string
-	SourceAddress  string
-	StaticLabels   LabelMap
-	Throttle       bool
-	PostTime       int
-	SleepTime      int
-	SendTime       int
-	ConsulEnabled  bool
-	Debug          bool
+	Application        string
+	ListenAddress      string
+	CycleInterval      int
+	ACITimeout         time.Duration
+	AmURL              string
+	ACIHosts           []string
+	AlertsCFGFile      string
+	SecretsCFGFile     string
+	Version            string
+	User               string
+	Pass               string
+	ac                 aci_config.Alerts
+	sc                 aci_config.Secrets
+	StaticLabels       LabelMap
+	Throttle           bool
+	PostTime           int
+	SleepTime          int
+	SendTime           int
+	ConsulEnabled      bool
+	ConsulACIGroupHost string
+	Debug              bool
 }

--- a/wrap/acigo/v1/aci_client.go
+++ b/wrap/acigo/v1/aci_client.go
@@ -66,6 +66,9 @@ func NewACIClient(cfg of.ACIClientConfig, log *logger.Logger) (*ACIClient, error
 		Pass:  cfg.Pass,
 		Debug: cfg.Debug,
 	}
+	if len(opts.Hosts) < 1 {
+		opts.Hosts = []string{"ignored"}
+	}
 	// Configure the new internal client.
 	client, err := aci.New(opts)
 	if err != nil {

--- a/wrap/acigo/v1/aci_client.go
+++ b/wrap/acigo/v1/aci_client.go
@@ -112,3 +112,18 @@ func (c *ACIClient) NodeList() (map[string]map[string]interface{}, error) {
 func (c *ACIClient) Logout() error {
 	return c.client.Logout()
 }
+
+// Allow set the ACI host on runtime
+func (c *ACIClient) SetHost(host string) {
+	c.client.Opt.Hosts = []string{host}
+}
+
+// Get the current ACI host
+func (c *ACIClient) GetHost() string {
+	if c != nil {
+		if len(c.client.Opt.Hosts) >= 1 {
+			return c.client.Opt.Hosts[0]
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Add a new option called aci-hosts instead of aci-host that allows passing multiple hosts seperated by ','. Also, fixed the consul query and added a way for balancing the load between multiple instances. The parameter is called aci-group-host, when the instance performs the query it will filter by the corresponding group-host. Which means, ACI hosts will be grouped by this key. If nothing is passed, then all the hosts are processed i.e. single instance is deployed.